### PR TITLE
Show placeholder on start

### DIFF
--- a/floating-labels.js
+++ b/floating-labels.js
@@ -6,4 +6,7 @@ $(function() {
   }).on("blur", ".floating-label-form-group", function() {
     $(this).removeClass("floating-label-form-group-with-focus");
   });
+  $(".floating-label-form-group").each(function(e){
+	  $(this).toggleClass("floating-label-form-group-with-value", !!$(this).find('input, textarea').val());
+  });
 });


### PR DESCRIPTION
If an input or a textarea has a starting value, the placeholder is not
showed at all.
This little each loop fix this small issue.
